### PR TITLE
Adds support for removing nodes

### DIFF
--- a/decoder.js
+++ b/decoder.js
@@ -39,7 +39,8 @@ class MutationDecoder {
 					break;
 				case tags.Remove:
 					index = extractValue(byte);
-					mutation = {type: "remove", index};
+					let child = iter.next().value;
+					mutation = {type: "remove", index, child};
 					yield mutation;
 					break;
 				case tags.Text:

--- a/done-mutation-test.js
+++ b/done-mutation-test.js
@@ -54,3 +54,27 @@ QUnit.test("Setting textContent", function(assert){
 	mo.observe(root, { childList: true, subtree: true, characterData: true });
 	article.textContent = "A title";
 });
+
+QUnit.test("Deleting TextNodes", function(assert){
+	var done = assert.async();
+
+	var root = document.createElement("div");
+	var article = document.createElement("article");
+	var tn = document.createTextNode("Article");
+	article.appendChild(tn);
+	root.appendChild(article);
+	helpers.fixture.el().appendChild(root);
+	var clone = root.cloneNode(true);
+
+	var encoder = new MutationEncoder(root);
+	var patcher = new MutationPatcher(clone);
+
+	var mo = new MutationObserver(function(records) {
+		patcher.patch(encoder.encode(records));
+		assert.equal(clone.firstChild.firstChild, null, "There is no child of article");
+		done();
+	});
+
+	mo.observe(root, { childList: true, subtree: true, characterData: true });
+	article.removeChild(tn);
+});

--- a/encoder.js
+++ b/encoder.js
@@ -77,7 +77,9 @@ class MutationEncoder {
 					for(j = 0, jLen = record.removedNodes.length; j < jLen; j++) {
 						let node = record.removedNodes[j];
 
-						if(nodeMoved(node, j, records)) {
+
+
+						if(false && nodeMoved(node, j, records)) {
 							// TODO implement node moving
 
 							movedNodes.add(node);
@@ -85,18 +87,25 @@ class MutationEncoder {
 							yield 1; // parent index
 							yield 0; // ref
 						} else {
-							yield tagValue(index.for(node), tags.Remove);
+							let [parentIndex, childIndex] = index.fromParent(node);
+							index.purge(node);
+							yield tagValue(parentIndex, tags.Remove);
+							yield childIndex;
 						}
 					}
 
 					for (let node of record.addedNodes) {
 						// If this node was moved we have already done a move instruction
 						if(movedNodes.has(node)) {
+							throw new Error("Moving nodes is not yet supported");
 							movedNodes.delete(node);
 							continue;
 						}
 
-						yield tagValue(index.for(node.parentNode), tags.Insert);
+						let parentIndex = index.for(node.parentNode);
+						index.reIndexFrom(node);
+
+						yield tagValue(parentIndex, tags.Insert);
 						yield getChildIndex(node.parentNode, node); // ref
 						yield* encodeNode(node);
 					}

--- a/encoder.js
+++ b/encoder.js
@@ -98,8 +98,8 @@ class MutationEncoder {
 						// If this node was moved we have already done a move instruction
 						if(movedNodes.has(node)) {
 							throw new Error("Moving nodes is not yet supported");
-							movedNodes.delete(node);
-							continue;
+							//movedNodes.delete(node);
+							//continue;
 						}
 
 						let parentIndex = index.for(node.parentNode);

--- a/index.js
+++ b/index.js
@@ -1,16 +1,45 @@
+const parentSymbol = Symbol.for("done.parentNode");
 
 class NodeIndex {
 	constructor(root) {
 		this.root = root;
 		this.map = new WeakMap();
+		this.parentMap = new WeakMap();
 
 		//debugger;
 		this.walk(root);
 	}
 
+	reIndexFrom(node) {
+		// TODO make this not horrible.
+		// This should walk up the parents until it finds a parent without
+		// Any nextSiblings.
+		let startNode = this.root;
+		this.walk(startNode);
+
+		//let startIndex = this.map.get(startNode) + 1;
+		//this.walk(startNode, startIndex);
+
+	}
+
+	setParentIndex(searchNode) {
+		let parent = searchNode.parentNode;
+		let node = parent.firstChild;
+		let index = 0;
+
+		while(node && node !== searchNode) {
+			index++;
+			node = node.nextSibling;
+		}
+
+		this.parentMap.set(searchNode, index);
+	}
+
 	// Based on https://gist.github.com/cowboy/958000
 	walk(node, startIndex = 0) {
 		let skip, tmp;
+		let parentIndex = new Map();
+		parentIndex.set(node, 0);
 
 		// This depth value will be incremented as the depth increases and
 		// decremented as the depth decreases. The depth of the initial node is 0.
@@ -26,12 +55,23 @@ class NodeIndex {
 
 				// Set the index of this node
 				this.map.set(tmp, index);
+
+				parentIndex.set(node, 0);
+				this.parentMap.set(tmp, 0);
+				tmp[parentSymbol] = node;
+
 				index++;
 			} else if ( tmp = node.nextSibling ) {
 				// If skipping or there is no first child, get the next sibling. If
 				// there is a next sibling, reset the skip flag.
 				skip = false;
 				this.map.set(tmp, index);
+
+				let parentI = parentIndex.get(tmp.parentNode) + 1;
+				parentIndex.set(tmp.parentNode, parentI);
+				this.parentMap.set(tmp, parentI);
+				tmp[parentSymbol] = tmp.parentNode;
+
 				index++;
 			} else {
 				// Skipped or no first child and no next sibling, so traverse upwards,
@@ -62,18 +102,23 @@ class NodeIndex {
 			return this.map.get(node);
 		}
 
-		do {
-			node = node.parentNode;
-
-			if(this.map.has(node)) {
-				this.walk(node, this.map.get(node) + 1);
-				return this.map.get(searchNode);
-			}
-		} while(node !== root);
+		throw new Error("We don't know about this node", searchNode);
 	}
 
-	purge() {
+	fromParent(node) {
+		let parent = node[parentSymbol];
+		let parentIndex = this.for(parent);
+		let childIndex = this.parentMap.get(node);
+		return [parentIndex, childIndex];
+	}
 
+	purge(node) {
+		// TODO this should do something different...
+		let index = this.for(node);
+		this.reIndexFrom(node);
+		this.map.delete(node);
+		this.parentMap.delete(node);
+		return index;
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -10,16 +10,12 @@ class NodeIndex {
 		this.walk(root);
 	}
 
-	reIndexFrom(node) {
+	reIndexFrom() {
 		// TODO make this not horrible.
 		// This should walk up the parents until it finds a parent without
 		// Any nextSiblings.
 		let startNode = this.root;
 		this.walk(startNode);
-
-		//let startIndex = this.map.get(startNode) + 1;
-		//this.walk(startNode, startIndex);
-
 	}
 
 	setParentIndex(searchNode) {
@@ -94,15 +90,12 @@ class NodeIndex {
 
 	// Get the cached index of a Node. If you can't find that,
 	// Walk up to a parent that is indexed. At that point index down its children.
-	for(searchNode) {
-		let node = searchNode;
-		let root = this.root;
-
+	for(node) {
 		if(this.map.has(node)) {
 			return this.map.get(node);
 		}
 
-		throw new Error("We don't know about this node", searchNode);
+		throw new Error("We don't know about this node", node);
 	}
 
 	fromParent(node) {

--- a/patch.js
+++ b/patch.js
@@ -37,7 +37,7 @@ class MutationPatcher {
 		const document = root.ownerDocument;
 
 		for(let byte of iter) {
-			let index, ref;
+			let index, ref, child;
 
 			switch(extractTag(byte)) {
 				case tags.Zero:
@@ -46,9 +46,9 @@ class MutationPatcher {
 					index = extractValue(byte);
 					ref = iter.next().value;
 					let nodeType = iter.next().value;
-					let child = decodeNode(iter, nodeType, document);
+					child = decodeNode(iter, nodeType, document);
 					let parent = this.walker.next(index).value;
-					let sibling = getSibling(parent, ref);
+					let sibling = getChild(parent, ref);
 					parent.insertBefore(child, sibling);
 					break;
 				case tags.Move:
@@ -58,8 +58,10 @@ class MutationPatcher {
 					throw new Error('Moves have not been implemented');
 				case tags.Remove:
 					index = extractValue(byte);
+					let childIndex = iter.next().value;
 					let el = this.walker.next(index).value;
-					el.parentNode.removeChild(el);
+					child = getChild(el, childIndex);
+					el.removeChild(child);
 					this._startWalker();
 					break;
 				case tags.Text:
@@ -76,7 +78,7 @@ class MutationPatcher {
 	}
 }
 
-function getSibling(parent, index) {
+function getChild(parent, index) {
 	let i = 0, child = parent.firstChild;
 	while(i < index) {
 		i++;


### PR DESCRIPTION
This adds support for removing nodes, and as a result, for
`el.textContent` as well.

Now everything except for node moving is implemented (and that's
probably not necessary.