### PR TITLE
Reindex when the first call to .encode() is made

### DIFF
--- a/done-mutation-test.js
+++ b/done-mutation-test.js
@@ -1,3 +1,4 @@
 require("./test/test-textnodes");
 require("./test/test-attributes");
 require("./test/test-forms");
+require("./test/test-childlist");

--- a/encoder.js
+++ b/encoder.js
@@ -74,6 +74,7 @@ function* encodeNode(node) {
 class MutationEncoder {
 	constructor(root) {
 		this.index = new NodeIndex(root);
+		this._indexed = false;
 	}
 
 	encodeEvent(event) {
@@ -85,6 +86,7 @@ class MutationEncoder {
 	}
 
 	*mutations(records) {
+		this._initIndex();
 		const index = this.index;
 		const movedNodes = new WeakSet();
 
@@ -150,6 +152,7 @@ class MutationEncoder {
 	}
 
 	*event(event) {
+		this._initIndex();
 		let index = this.index;
 		switch(event.type) {
 			case "change":
@@ -164,6 +167,12 @@ class MutationEncoder {
 				break;
 			default:
 				throw new Error(`Encoding the event '${event.type}' is not supported.`);
+		}
+	}
+
+	_initIndex() {
+		if(!this._indexed) {
+			this.index.indexRoot();
 		}
 	}
 }

--- a/index.js
+++ b/index.js
@@ -5,9 +5,11 @@ class NodeIndex {
 		this.root = root;
 		this.map = new WeakMap();
 		this.parentMap = new WeakMap();
+		this.indexRoot();
+	}
 
-		//debugger;
-		this.walk(root);
+	indexRoot() {
+		this.walk(this.root);
 	}
 
 	reIndexFrom() {

--- a/test/test-childlist.js
+++ b/test/test-childlist.js
@@ -1,0 +1,35 @@
+var QUnit = require("steal-qunit");
+var MutationEncoder = require("../encoder");
+var MutationPatcher = require("../patch");
+var MutationDecoder = require("../decoder");
+var helpers = require("./test-helpers");
+
+QUnit.module("Node insertion/removal", {
+	afterEach: function(){
+		helpers.fixture.clear();
+	}
+});
+
+QUnit.test("Nodes inserted before MutationObserver starts observing", function(assert){
+	var done = assert.async();
+
+	var root = document.createElement("div");
+	helpers.fixture.el().appendChild(root);
+	var clone = root.cloneNode(true);
+
+	var encoder = new MutationEncoder(root);
+	var decoder = new MutationDecoder(root.ownerDocument);
+
+	var article = document.createElement("article");
+	root.appendChild(article);
+
+	var mo = new MutationObserver(function(records) {
+		var instr = Array.from(decoder.decode(encoder.encode(records)));
+		assert.equal(instr.length, 1, "There is one mutation instruction");
+		assert.equal(instr[0].node.nodeName, "SPAN", "span mutation observed");
+		done();
+	});
+
+	mo.observe(root, { subtree: true, childList: true });
+	article.appendChild(document.createElement("span"));
+});


### PR DESCRIPTION
It's possible that nodes are manipulated in between creating the
MutationEncoder and the first time `.encode()` is called. For this
reason we should reindex on the first .encode() call.