### PR TITLE
Switch to 8 bit arrays

### DIFF
--- a/encoder.js
+++ b/encoder.js
@@ -78,11 +78,11 @@ class MutationEncoder {
 	}
 
 	encodeEvent(event) {
-		return Uint16Array.from(this.event(event));
+		return Uint8Array.from(this.event(event));
 	}
 
 	encode(records) {
-		return Uint16Array.from(this.mutations(records));
+		return Uint8Array.from(this.mutations(records));
 	}
 
 	*mutations(records) {


### PR DESCRIPTION
Calls to stream.write(arr) in Node can only take 8 bit arrays and I
can't think of a reason why 16 bit was needed.