### PR TITLE
Allow user-provided NodeIndex

### DIFF
--- a/encoder.js
+++ b/encoder.js
@@ -72,8 +72,13 @@ function* encodeNode(node) {
 }
 
 class MutationEncoder {
-	constructor(root) {
-		this.index = new NodeIndex(root);
+	constructor(rootOrIndex) {
+		if(rootOrIndex instanceof NodeIndex) {
+			this.index = rootOrIndex;
+		} else {
+			this.index = new NodeIndex(rootOrIndex);
+		}
+
 		this._indexed = false;
 	}
 
@@ -86,7 +91,6 @@ class MutationEncoder {
 	}
 
 	*mutations(records) {
-		this._initIndex();
 		const index = this.index;
 		const movedNodes = new WeakSet();
 
@@ -152,7 +156,6 @@ class MutationEncoder {
 	}
 
 	*event(event) {
-		this._initIndex();
 		let index = this.index;
 		switch(event.type) {
 			case "change":
@@ -167,12 +170,6 @@ class MutationEncoder {
 				break;
 			default:
 				throw new Error(`Encoding the event '${event.type}' is not supported.`);
-		}
-	}
-
-	_initIndex() {
-		if(!this._indexed) {
-			this.index.indexRoot();
 		}
 	}
 }

--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ class NodeIndex {
 		let index = this;
 		records.forEach(function(record){
 			record.addedNodes.forEach(function(node){
-				index.reIndexFrom(node)
+				index.reIndexFrom(node);
 			});
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "done-mutation",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "done-mutation.js",
   "description": "Encodes MutationRecords so they can be patched on other documents",
   "homepage": "https://github.com/donejs/done-mutation",

--- a/test/test-childlist.js
+++ b/test/test-childlist.js
@@ -2,6 +2,7 @@ var QUnit = require("steal-qunit");
 var MutationEncoder = require("../encoder");
 var MutationPatcher = require("../patch");
 var MutationDecoder = require("../decoder");
+var NodeIndex = require("../index");
 var helpers = require("./test-helpers");
 
 QUnit.module("Node insertion/removal", {
@@ -17,7 +18,9 @@ QUnit.test("Nodes inserted before MutationObserver starts observing", function(a
 	helpers.fixture.el().appendChild(root);
 	var clone = root.cloneNode(true);
 
-	var encoder = new MutationEncoder(root);
+	var index = new NodeIndex(root);
+	index.startObserving();
+	var encoder = new MutationEncoder(index);
 	var decoder = new MutationDecoder(root.ownerDocument);
 
 	var article = document.createElement("article");
@@ -27,6 +30,7 @@ QUnit.test("Nodes inserted before MutationObserver starts observing", function(a
 		var instr = Array.from(decoder.decode(encoder.encode(records)));
 		assert.equal(instr.length, 1, "There is one mutation instruction");
 		assert.equal(instr[0].node.nodeName, "SPAN", "span mutation observed");
+		index.stopObserving();
 		done();
 	});
 


### PR DESCRIPTION
This allows the user to provide a NodeIndex to the MutationEncoder. This
is so that the user can monitor mutations themselves to keep the
NodeIndex up-to-date.