### PR TITLE
Implements grouped removals

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,5 +2,8 @@
 [*]
 end_of_line = LF
 indent_style = tab
-trim_trailing_whitespace = false
-insert_final_newline = true
+indent_size = 4
+
+[{*.json,*.yml,*.md}]
+indent_style = space
+indent_size = 2

--- a/patch.js
+++ b/patch.js
@@ -5,7 +5,7 @@ const {
 const tags = require("./tags");
 
 function* walk(root, nextIndex) {
-	const document = root.ownerDocument;
+	const document = getDocument(root);
 	const walker = document.createTreeWalker(root, -1);
 	let index = 0;
 	let currentNode = walker.nextNode();
@@ -23,6 +23,10 @@ function* walk(root, nextIndex) {
 	}
 }
 
+function getDocument(node) {
+		return node.nodeType === 9 ? node : node.ownerDocument;
+}
+
 class MutationPatcher {
 	constructor(root) {
 		this.root = root;
@@ -37,7 +41,7 @@ class MutationPatcher {
 	patch(bytes) {
 		const iter = bytes[Symbol.iterator]();
 		const root = this.root;
-		const document = root.ownerDocument;
+		const document = getDocument(root);
 
 		for(let byte of iter) {
 			let index, ref, node, child;


### PR DESCRIPTION
MutationRecords will contain groupings of removed and added nodes. It
looks something like:

```
[
  {removedNodes: [1]},
  {removedNodes: [2]},
  {removedNodes: [3]},
  {addedNodes: [14]},
  {addedNodes: [15]},
  {removedNodes: [5]},
  {removedNodes: [6]},
  {addedNodes: [13]}
]
```

This commit ensures that we process removed nodes in reverse order, so
that the indices stay correct. In the above example we will:

1. Remove node 3
2. Remove node 2
3. Remove node 1
4. Add node 14
5. Add node 15
6. Remove node 6
7. Remove node 5
8. Add node 13

It's possible that we should be going in another order (6,5,3,2,1), and
actually doing *all* removals for the entire records set in reverse
order, but I haven't ran into that sort of scenario yet.