### PR TITLE
Encode 16 bit indices in 8 bit arrays

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -3,15 +3,12 @@ const tags = require("./tags");
 exports.decodeNode = decodeNode;
 exports.decodeString = decodeString;
 exports.decodeType = decodeType;
-exports.extractTag = extractTag;
-exports.extractValue = extractValue;
+exports.toUint16 = toUint16;
 
-function extractTag(value) {
-	return value & ((1 << 3) - 1);
-}
-
-function extractValue(value) {
-	return value >>> 3;
+function toUint16(iter) {
+	let high = iter.next().value;
+	let low = iter.next().value;
+	return (((high & 255) << 8) | (low & 255));
 }
 
 function decodeString(bytes) {

--- a/decoder.js
+++ b/decoder.js
@@ -2,8 +2,7 @@ const {
 	decodeString,
 	decodeNode,
 	decodeType,
-	extractTag,
-	extractValue
+	toUint16
 } = require("./decode");
 const tags = require("./tags");
 
@@ -20,55 +19,55 @@ class MutationDecoder {
 		for(let byte of iter) {
 			let index, ref;
 
-			switch(extractTag(byte)) {
+			switch(byte) {
 				case tags.Zero:
 					break;
 				case tags.Insert:
-					index = extractValue(byte);
-					ref = iter.next().value;
+					index = toUint16(iter);
+					ref = toUint16(iter);
 					let nodeType = iter.next().value;
 					mutation = {type: "insert", index, ref, nodeType};
 					mutation.node = decodeNode(iter, nodeType, document);
 					yield mutation;
 					break;
 			  case tags.Move:
-					index = extractValue(byte);
+					index = toUint16(iter);
 					let from = iter.next().value;
 					ref = iter.next().value;
 					mutation = {type: "move", from, index, ref};
 					yield mutation;
 					break;
 				case tags.Remove:
-					index = extractValue(byte);
+					index = toUint16(iter);
 					let child = iter.next().value;
 					mutation = {type: "remove", index, child};
 					yield mutation;
 					break;
 				case tags.Text:
-					index = extractValue(byte);
+					index = toUint16(iter);
 					let value = decodeString(iter);
 					mutation = {type: "text", index, value};
 					yield mutation;
 					break;
 				case tags.SetAttr:
-					index = extractValue(byte);
+					index = toUint16(iter);
 					let attrName = decodeString(iter);
 					let newValue = decodeString(iter);
 					mutation = {type: "set-attribute", index, attrName, newValue};
 					yield mutation;
 					break;
 				case tags.RemoveAttr:
-					index = extractValue(byte);
+					index = toUint16(iter);
 					mutation = {type: "remove-attribute", index, attrName: decodeString(iter)};
 					yield mutation;
 					break;
 				case tags.Prop:
-					index = extractValue(byte);
+					index = toUint16(iter);
 					mutation = {type: "property", index, property: decodeString(iter), value: decodeType(iter)};
 					yield mutation;
 					break;
 				default:
-					throw new Error(`Cannot decode instruction '${extractTag(byte)}'.`);
+					throw new Error(`Cannot decode instruction '${byte}'.`);
 			}
 		}
 	}


### PR DESCRIPTION
Trees exceed 255 nodes will have indices too large to fit into the 8bit
arrays, so this fixes that by encoding them into 2 bytes.