### PR TITLE
Fix mutation ordering

### DIFF
--- a/ordering.md
+++ b/ordering.md
@@ -1,0 +1,9 @@
+
+```js
+{ type: "remove", index: 6 }
+{ type: "remove", index: 5 }
+{ type: "remove", index: 4 }
+{ type: "add", index: 2 }
+{ type: "add", index: 3 }
+{ type: "characterData": index 4 }
+{ type: "attributes": index 4 }


### PR DESCRIPTION
This fixes mutation ordering so that we always go in a priority of:

1. Removals first
  1. Later index first (including child index)
1. For additions, lower index firt
1. characterData and attributes can come later.

Fixes #15