### PR TITLE
Defer creating indices until after a set of mutations

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,6 @@ class NodeIndex {
 	purge(node) {
 		// TODO this should do something different...
 		let index = this.for(node);
-		this.reIndexFrom(node);
 		this.map.delete(node);
 		this.parentMap.delete(node);
 		return index;


### PR DESCRIPTION
This prevents us from reindexing the Nodes until after processing a set
of mutations. This ensures that the indices match what is in the
patching document.