### PR TITLE
Keep textnodes in sync

### DIFF
--- a/encoder.js
+++ b/encoder.js
@@ -1,5 +1,6 @@
 const tags = require("./tags");
 const NodeIndex = require("./index");
+const { shouldIncrementIndex, updateSiblings } = require("./textnodes");
 
 function* toUint8(n) {
 	yield ((n >> 8) & 0xff); // high
@@ -135,6 +136,7 @@ class MutationEncoder {
 
 						let [parentIndex, childIndex] = index.fromParent(node);
 						index.purge(node);
+						updateSiblings(node, record);
 						yield tags.Remove;
 						yield* toUint8(parentIndex);
 						yield* toUint8(childIndex);
@@ -226,7 +228,7 @@ function getChildIndex(parent, child, collapseTextNodes) {
 	let prev;
 	while(node) {
 		let increment = true;
-		if(collapseTextNodes && prev && prev.nodeType === 3 && node.nodeType === 3) {
+		if(!shouldIncrementIndex(collapseTextNodes, node, prev)) {
 			increment = false;
 		}
 
@@ -247,6 +249,5 @@ function getChildIndex(parent, child, collapseTextNodes) {
 function isRemovalRecord(record) {
 	return record.removedNodes.length > 0 && record.addedNodes.length === 0;
 }
-
 
 module.exports = MutationEncoder;

--- a/log.js
+++ b/log.js
@@ -10,8 +10,8 @@ exports.instructions = function(bytes) {
 	console.groupEnd();
 };
 
-exports.element = function(root) {
-	let encoder = new MutationEncoder(root);
+exports.element = function(root, options) {
+	let encoder = new MutationEncoder(root, options);
 	let decoder = new MutationDecoder(root.ownerDocument);
 
 	function callback(records) {

--- a/test/test-childlist.js
+++ b/test/test-childlist.js
@@ -517,7 +517,7 @@ QUnit.test("Applying changes to a full app load", async function(assert) {
 	done();
 });
 
-QUnit.test("Disabling consecutive TextNode indexing", function(assert) {
+QUnit.test("collapseTextNodes", function(assert) {
 	var done = assert.async();
 
 	var root = document.createElement("div");
@@ -545,5 +545,36 @@ QUnit.test("Disabling consecutive TextNode indexing", function(assert) {
 	mo.observe(root, { childList: true, subtree: true});
 
 	h1.removeChild(h1.firstChild.nextSibling);
+	h1.appendChild(document.createTextNode("second"));
+});
+
+
+QUnit.test("collapseTextNodes when Text is inserted after", function(assert) {
+	var done = assert.async();
+
+	var root = document.createElement("div");
+	root.appendChild(document.createTextNode("\n"));
+	root.appendChild(document.createTextNode(""));
+	var h1 = document.createElement("h1");
+	h1.appendChild(document.createTextNode(""));
+	h1.appendChild(document.createTextNode("first"));
+	root.appendChild(h1);
+	helpers.fixture.el().appendChild(root);
+	var clone = root.cloneNode();
+	clone.innerHTML = root.innerHTML;
+
+	var encoder = new MutationEncoder(root, { collapseTextNodes: true });
+	var patcher = new MutationPatcher(clone);
+
+	var mo = new MutationObserver(function(records) {
+		var bytes = encoder.encode(records);
+		patcher.patch(bytes);
+
+		assert.equal(clone.textContent.trim(), "firstsecond");
+		done();
+	});
+
+	mo.observe(root, { childList: true, subtree: true});
+
 	h1.appendChild(document.createTextNode("second"));
 });

--- a/textnodes.js
+++ b/textnodes.js
@@ -1,0 +1,58 @@
+const initialNodeSymbol = Symbol.for("done.initialNode");
+const deletedNodeSymbol = Symbol.for("done.deletedNode");
+
+exports.markInitial = function markInitial(markInitialTextNodes, node) {
+	if(markInitialTextNodes) {
+		node[initialNodeSymbol] = true;
+	}
+};
+
+function isInitialNode(node) {
+	return node && node[initialNodeSymbol];
+}
+
+exports.shouldIncrementIndex = function shouldIncrementIndex(collapseTextNodes, node, previousSibling) {
+	if(collapseTextNodes && node[deletedNodeSymbol]) {
+		return false;
+	}
+
+	if(collapseTextNodes && previousSibling && previousSibling.nodeType === 3 && node.nodeType === 3) {
+		if(previousSibling[initialNodeSymbol] && node[initialNodeSymbol]) {
+			return false;
+		}
+	}
+
+	return true;
+};
+
+// Update sibling TextNodes when a node is removed from the document
+exports.updateSiblings = function(node, record) {
+	if(node[initialNodeSymbol]) {
+		if(record.previousSibling) {
+			if(isInitialNode(record.previousSibling)) {
+				record.previousSibling[deletedNodeSymbol] = true;
+			}
+		}
+
+		if(record.nextSibling) {
+			if(isInitialNode(record.nextSibling)) {
+				record.nextSibling[deletedNodeSymbol] = true;
+			}
+		}
+
+		/*if(!record.previousSibling) {
+			if(record.nextSibling) {
+				if(!isInitialNode(record.nextSibling.nextSibling)) {
+					delete record.nextSibling[initialNodeSymbol];
+				}
+			}
+		}
+		else if(!record.nextSibling) {
+			if(record.previousSibling) {
+				if(!isInitialNode(record.previousSibling.previousSibling)) {
+					delete record.previousSibling[initialNodeSymbol];
+				}
+			}
+		}*/
+	}
+};


### PR DESCRIPTION
When text nodes change in the source document, ensure that are
instructions account for the fact that the destination document will
have a different number of text nodes.