### PR TITLE
Expose a `reindex` method on NodeIndex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js: node
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+addons:
+  firefox: "63.0"

--- a/encoder.js
+++ b/encoder.js
@@ -218,7 +218,7 @@ class MutationEncoder {
 	}
 }
 
-function getChildIndex(parent, child, collapseTextNodes) {
+function getChildIndex(parent, child) {
 	let index = -1;
 	let node = parent.firstChild;
 	let prev;

--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ class NodeIndex {
 		this._onMutations = this._onMutations.bind(this);
 	}
 
+	reindex() {
+		this.walk(this.root);
+	}
+
 	reIndexFrom() {
 		// TODO make this not horrible.
 		// This should walk up the parents until it finds a parent without

--- a/test/test-childlist.js
+++ b/test/test-childlist.js
@@ -581,3 +581,29 @@ QUnit.test("Consecutive TextNodes and appending", function(assert) {
 
 	h1.appendChild(document.createTextNode("second"));
 });
+
+QUnit.test("NodeIndex exposes a reindex function", function(assert) {
+	var done = assert.async();
+
+	var root = document.createElement("div");
+	helpers.fixture.el().appendChild(root);
+	var clone = root.cloneNode(true);
+
+	var index = new NodeIndex(root);
+	var encoder = new MutationEncoder(index);
+	var decoder = new MutationDecoder(root.ownerDocument);
+
+	var article = document.createElement("article");
+	root.appendChild(article);
+
+	var mo = new MutationObserver(function(records) {
+		var instr = Array.from(decoder.decode(encoder.encode(records)));
+		assert.equal(instr.length, 1, "There is one mutation instruction");
+		assert.equal(instr[0].node.nodeName, "SPAN", "span mutation observed");
+		done();
+	});
+
+	index.reindex();
+	mo.observe(root, { subtree: true, childList: true });
+	article.appendChild(document.createElement("span"));
+});

--- a/test/test-childlist.js
+++ b/test/test-childlist.js
@@ -523,7 +523,7 @@ QUnit.test("Consecutive TextNodes and replacement", function(assert) {
 
 	var root = document.createElement("div");
 	root.appendChild(document.createTextNode("\n"));
-	root.appendChild(document.createTextNode(""));
+	root.appendChild(document.createTextNode("\n"));
 	var h1 = document.createElement("h1");
 	h1.appendChild(document.createTextNode("\n"));
 	h1.appendChild(document.createTextNode("first"));
@@ -531,6 +531,7 @@ QUnit.test("Consecutive TextNodes and replacement", function(assert) {
 	helpers.fixture.el().appendChild(root);
 	var clone = root.cloneNode();
 	clone.innerHTML = cloneUtils.serializeToString(root);
+	clone = clone.firstChild;
 
 	var encoder = new MutationEncoder(root);
 	var patcher = new MutationPatcher(clone);
@@ -565,6 +566,7 @@ QUnit.test("Consecutive TextNodes and appending", function(assert) {
 	helpers.fixture.el().appendChild(root);
 	var clone = root.cloneNode();
 	clone.innerHTML = cloneUtils.serializeToString(root);
+	clone = clone.firstChild;
 
 	var encoder = new MutationEncoder(root);
 	var patcher = new MutationPatcher(clone);


### PR DESCRIPTION
This makes it so that NodeIndex has a "reindex" method that gives
outside code a chance to completely reindex the document in cases where
DOM mutations have occurred *after* the NodeIndex was created.