### PR TITLE
Order mutations by hierarchy

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,11 +13,7 @@ class NodeIndex {
 		this.walk(this.root);
 	}
 
-	reIndexFrom() {
-		// TODO make this not horrible.
-		// This should walk up the parents until it finds a parent without
-		// Any nextSiblings.
-		let startNode = this.root;
+	reIndexFrom(startNode) {
 		this.walk(startNode);
 	}
 
@@ -140,7 +136,7 @@ class NodeIndex {
 		let index = this;
 		records.forEach(function(record){
 			record.addedNodes.forEach(function(node){
-				index.reIndexFrom(node);
+				index.reIndexFrom(node.parentNode);
 			});
 		});
 	}

--- a/ordering.md
+++ b/ordering.md
@@ -7,3 +7,4 @@
 { type: "add", index: 3 }
 { type: "characterData": index 4 }
 { type: "attributes": index 4 }
+```


### PR DESCRIPTION
This orders mutations by hierarchy and then type.

Things further down in document order occur first. Removals happen
before insertions (when they have the same parent). Insertions happen in
document order. This should ensure that everything occurs in the correct
order.