### PR TITLE
Handle case were a node is appended in the same...

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const walk = require("./walk");
 const parentSymbol = Symbol.for("done.parentNode");
 
 class NodeIndex {
@@ -32,59 +33,32 @@ class NodeIndex {
 
 	// Based on https://gist.github.com/cowboy/958000
 	walk(node, startIndex = 0) {
-		let skip, tmp;
 		let parentIndex = new Map();
 		parentIndex.set(node, 0);
 
-		// This depth value will be incremented as the depth increases and
-		// decremented as the depth decreases. The depth of the initial node is 0.
-		let depth = 0;
-		let index = startIndex;
+		walk(node, (type, node, child, index) => {
+			switch(type) {
+				case 'child': {
+					// Set the index of this node
+					this.map.set(child, index);
 
-		// Always start with the initial element.
-		do {
-			if ( !skip && (tmp = node.firstChild) ) {
-				// If not skipping, get the first child. If there is a first child,
-				// increment the index since traversing downwards.
-				depth++;
+					parentIndex.set(node, 0);
+					this.parentMap.set(child, 0);
+					child[parentSymbol] = node;
+					break;
+				}
+				case 'sibling': {
+					this.map.set(child, index);
 
-				// Set the index of this node
-				this.map.set(tmp, index);
+					let parentI = parentIndex.get(child.parentNode) + 1;
+					parentIndex.set(child.parentNode, parentI);
+					this.parentMap.set(child, parentI);
 
-				parentIndex.set(node, 0);
-				this.parentMap.set(tmp, 0);
-				tmp[parentSymbol] = node;
-				index++;
-			} else if ( tmp = node.nextSibling ) {
-				// If skipping or there is no first child, get the next sibling. If
-				// there is a next sibling, reset the skip flag.
-				skip = false;
-				this.map.set(tmp, index);
-
-
-				let parentI = parentIndex.get(tmp.parentNode) + 1;
-				parentIndex.set(tmp.parentNode, parentI);
-				this.parentMap.set(tmp, parentI);
-
-				tmp[parentSymbol] = tmp.parentNode;
-				index++;
-			} else {
-				// Skipped or no first child and no next sibling, so traverse upwards,
-				tmp = node.parentNode;
-				// and decrement the depth.
-				depth--;
-				// Enable skipping, so that in the next loop iteration, the children of
-				// the now-current node (parent node) aren't processed again.
-				skip = true;
+					child[parentSymbol] = child.parentNode;
+					break;
+				}
 			}
-
-			// Instead of setting node explicitly in each conditional block, use the
-			// tmp var and set it here.
-			node = tmp;
-
-			// Stop if depth comes back to 0 (or goes below zero, in conditions where
-			// the passed node has neither children nore next siblings).
-		} while ( depth > 0 );
+		}, startIndex);
 	}
 
 	// Get the cached index of a Node. If you can't find that,

--- a/test/test-childlist.js
+++ b/test/test-childlist.js
@@ -671,4 +671,36 @@ QUnit.test("Element removed from parent before parent's insert occurs", function
 	parent.appendChild(document.createElement("label"));
 	root.appendChild(parent);
 	parent.removeChild(parent.firstChild);
-})
+});
+
+QUnit.test("Element appended to parent before parent's insert occurs", function(assert) {
+	var done = assert.async();
+
+	var doc = document.createElement("div");
+	var root = document.createElement("div");
+	doc.appendChild(root);
+	helpers.fixture.el().appendChild(doc);
+	var clone = doc.cloneNode(true);
+
+	var encoder = new MutationEncoder(doc);
+	var patcher = new MutationPatcher(clone);
+
+	function patch(records) {
+		var bytes = encoder.encode(records);
+		patcher.patch(bytes);
+	}
+
+	var mo = new MutationObserver(function(records){
+		patch(records);
+
+		assert.equal(clone.firstChild.firstChild.firstChild.nodeName, "LABEL", "there's just a label");
+		done();
+	});
+	mo.observe(root, { subtree: true, childList: true });
+
+	var parent = document.createElement("main");
+	var label = document.createElement("label");
+	parent.appendChild(label);
+	root.appendChild(parent);
+	label.appendChild(document.createTextNode("User"));
+});

--- a/walk.js
+++ b/walk.js
@@ -1,0 +1,24 @@
+
+module.exports = function(node, callback, startIndex = 0) {
+	let skip, tmp;
+	let depth = 0;
+	let index = startIndex;
+
+	// Always start with the initial element.
+	do {
+		if ( !skip && (tmp = node.firstChild) ) {
+			depth++;
+			callback('child', node, tmp, index);
+			index++;
+		} else if ( tmp = node.nextSibling ) {
+			skip = false;
+			callback('sibling', node, tmp, index);
+			index++;
+		} else {
+			tmp = node.parentNode;
+			depth--;
+			skip = true;
+		}
+		node = tmp;
+	} while ( depth > 0 );
+};


### PR DESCRIPTION
mutation set where the parent was added. In this case we don't need to
encode the child's mutatation. We prevent this by keeping a set of all
nodes that are added.