### PR TITLE
Support encoding/decoding comments

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -42,6 +42,8 @@ function decodeNode(bytes, nodeType, document) {
 			return document.createTextNode(decodeString(bytes));
 		case 1:
 			return decodeElement(bytes, document);
+		case 8:
+			return document.createComment(decodeString(bytes));
 		default:
 			throw new Error(`Unable to decode nodeType ${nodeType}`);
 	}

--- a/encoder.js
+++ b/encoder.js
@@ -68,6 +68,7 @@ function* encodeNode(node) {
 			yield* encodeElement(node);
 			break;
 		case 3:
+		case 8:
 			yield* encodeString(node.nodeValue);
 			break;
 		default:

--- a/test/test-childlist.js
+++ b/test/test-childlist.js
@@ -704,3 +704,27 @@ QUnit.test("Element appended to parent before parent's insert occurs", function(
 	root.appendChild(parent);
 	label.appendChild(document.createTextNode("User"));
 });
+
+QUnit.test("Correctly encodes/decodes comment nodes", function(assert) {
+	var done = assert.async();
+
+	var doc = document.createElement("div");
+	var root = document.createElement("div");
+	doc.appendChild(root);
+	helpers.fixture.el().appendChild(doc);
+	var clone = doc.cloneNode(true);
+
+	var encoder = new MutationEncoder(doc);
+	var patcher = new MutationPatcher(clone);
+
+	var mo = new MutationObserver(function(records){
+		var bytes = encoder.encode(records);
+		patcher.patch(bytes);
+
+		assert.equal(clone.firstChild.firstChild.nodeValue, "hello world");
+		done();
+	});
+	mo.observe(root, { subtree: true, childList: true });
+
+	root.appendChild(document.createComment("hello world"));
+});


### PR DESCRIPTION
This makes it so that mutations that include comments are encoded (and
		later decoded).